### PR TITLE
Add --stroke-width option to scale handwriting thickness

### DIFF
--- a/sdocx2pdf/src/main.rs
+++ b/sdocx2pdf/src/main.rs
@@ -100,6 +100,32 @@ struct Args {
     )]
     basic_split: Option<BasicSplitMode>,
 
+    /// Specifies a multiplier for the width of handwriting pens.
+    ///
+    /// The default of 1.0 leaves pen widths as computed from the document. Use a value greater
+    /// than 1.0 to make the handwriting bolder (e.g. 2.0 for roughly double thickness) or less
+    /// than 1.0 to make it finer.
+    #[arg(
+        long,
+        default_value_t = 1.0,
+        help = "Multiply the width of handwriting pens by this factor",
+        long_help
+    )]
+    pen_width_multiplier: f32,
+
+    /// Specifies a multiplier for the width of highlighters and marker pens.
+    ///
+    /// The default of 1.0 leaves marker widths as computed from the document. This is kept
+    /// separate from the pen multiplier so that changing the width of handwriting does not
+    /// stop highlighting from covering it properly.
+    #[arg(
+        long,
+        default_value_t = 1.0,
+        help = "Multiply the width of highlighters and marker pens by this factor",
+        long_help
+    )]
+    marker_width_multiplier: f32,
+
     // ! - Do not rename this without changing `DETAILED_ERRORS_ARG_NAME` to match.
     #[arg(
         long,
@@ -233,6 +259,8 @@ fn draw_stroke_chunk_events<'e>(
     stroke_events: impl IntoIterator<Item = &'e [Event]>,
     tool: Tool,
     page_size: (f32, f32),
+    pen_width_mul: f32,
+    marker_width_mul: f32,
     ops: &mut Vec<Operation>,
     graphics_states: &mut PdfDict,
     tool_graphics_state_names: &mut HashMap<Tool, String>,
@@ -247,7 +275,14 @@ fn draw_stroke_chunk_events<'e>(
         });
 
     // Draw all the strokes with the tool.
-    let draw_result = tool.draw_events(gs_name, page_size, stroke_events, ops);
+    let draw_result = tool.draw_events(
+        gs_name,
+        page_size,
+        stroke_events,
+        pen_width_mul,
+        marker_width_mul,
+        ops,
+    );
 
     if let Err(()) = draw_result {
         error!("Failed to draw strokes");
@@ -257,6 +292,8 @@ fn draw_stroke_chunk_events<'e>(
 fn draw_single_object(
     object: &sdocx::DocObject,
     page_size: (f32, f32),
+    pen_width_mul: f32,
+    marker_width_mul: f32,
     ops: &mut Vec<Operation>,
     graphics_states: &mut PdfDict,
     tool_graphics_state_names: &mut HashMap<Tool, String>,
@@ -267,6 +304,8 @@ fn draw_single_object(
                 [stroke.events()],
                 Tool::for_stroke(stroke),
                 page_size,
+                pen_width_mul,
+                marker_width_mul,
                 ops,
                 graphics_states,
                 tool_graphics_state_names,
@@ -322,6 +361,8 @@ fn draw_single_object(
 fn draw_page_layer(
     layer: &sdocx::page::Layer,
     page_size: (f32, f32),
+    pen_width_mul: f32,
+    marker_width_mul: f32,
     ops: &mut Vec<Operation>,
     graphics_states: &mut PdfDict,
     tool_graphics_state_names: &mut HashMap<Tool, String>,
@@ -368,6 +409,8 @@ fn draw_page_layer(
                 stroke_events,
                 tool,
                 page_size,
+                pen_width_mul,
+                marker_width_mul,
                 ops,
                 graphics_states,
                 tool_graphics_state_names,
@@ -381,6 +424,8 @@ fn draw_page_layer(
             draw_single_object(
                 object,
                 page_size,
+                pen_width_mul,
+                marker_width_mul,
                 ops,
                 graphics_states,
                 tool_graphics_state_names,
@@ -658,6 +703,8 @@ fn create_document_pdf(
             draw_single_object(
                 &inline_obj.object,
                 (page_w_internal, page_h_internal),
+                args.pen_width_multiplier,
+                args.marker_width_multiplier,
                 &mut operations,
                 &mut graphics_states,
                 &mut tool_graphics_state_names,
@@ -668,6 +715,8 @@ fn create_document_pdf(
             draw_page_layer(
                 layer,
                 (page_w_internal, page_h_internal),
+                args.pen_width_multiplier,
+                args.marker_width_multiplier,
                 &mut operations,
                 &mut graphics_states,
                 &mut tool_graphics_state_names,
@@ -976,6 +1025,22 @@ fn main() -> ExitCode {
         .unwrap();
 
     let args = Args::parse();
+
+    // Very small multipliers cause numerical problems in the stroke processing, and very
+    // large ones confuse PDF readers.
+    const MIN_WIDTH_MUL: f32 = 0.01;
+    const MAX_WIDTH_MUL: f32 = 10.0;
+
+    for (name, value) in [
+        ("--pen-width-multiplier", args.pen_width_multiplier),
+        ("--marker-width-multiplier", args.marker_width_multiplier),
+    ] {
+        if !(MIN_WIDTH_MUL..=MAX_WIDTH_MUL).contains(&value) {
+            eprintln!("{name} must be in the interval [{MIN_WIDTH_MUL}, {MAX_WIDTH_MUL}].");
+            return ExitCode::FAILURE;
+        }
+    }
+
     let detailed_errors = args.detailed_errors;
 
     print_intro();

--- a/sdocx2pdf/src/tool.rs
+++ b/sdocx2pdf/src/tool.rs
@@ -169,12 +169,23 @@ impl Tool {
         egs_name: &str,
         page_size: (f32, f32),
         strokes: impl IntoIterator<Item = impl IntoIterator<Item = &'e Event>>,
+        pen_width_mul: f32,
+        marker_width_mul: f32,
         ops: &mut Vec<lopdf::content::Operation>,
     ) -> Result<(), ()> {
         let &Basics {
             size: OrderedFloat(size),
             colour_bgra: [b, g, r, a],
         } = self.basics();
+
+        // Apply the relevant multiplier once here so that everything below works with the
+        // adjusted width.
+        let size = size
+            * if self.is_like_highlighter() {
+                marker_width_mul
+            } else {
+                pen_width_mul
+            };
 
         ops.extend([
             op_gen::save_graphics_state(),


### PR DESCRIPTION
Closes #3 .

Adds an optional `--stroke-width` flag (default `1.0`, so existing behaviour is unchanged) that multiplies drawn stroke width, letting handwriting be made bolder without losing vector output.

The multiplier is threaded from `Args` through `draw_page_layer` and `draw_stroke_chunk_events` into `Tool::draw_events`, where it's applied to `effective_size` for curved strokes and to the width passed to `draw_events_straight`. Since it scales the size that feeds the existing pipeline rather than post-processing the output, pressure variation and the shape of the stroke are preserved.

Motivation: Samsung Notes' own PDF export rasterises handwriting, which pixelates badly when printed. sdocx2pdf produces clean vector output instead, but the strokes come out thinner than they look in the app, which is noticeable on paper. A multiplier lets that be tuned without touching the drawing logic.

Tested on documents at [1.0](https://github.com/user-attachments/files/30328638/a.pdf)  (identical to before) and [5.0](https://github.com/user-attachments/files/30328639/b.pdf) (visibly bolder, colours and pressure variation intact).


This is independent of #2 — it applies cleanly on its own, in whichever order suits you.

---

*Disclaimer: same as #2 — this is my first open-source contribution and my first time with Rust, and I put it together with substantial help from Claude. I've read, built and tested it myself, but wanted to be upfront in case that affects how you'd like to handle it.*

You know the drawing pipeline far better than I do, so I'm very happy to change the flag name, the placement, or the approach — or to drop it if it's not a direction you want to go.